### PR TITLE
Bump net.minecraftforge.gradleutils from 2.6.1 to 3.2.5

### DIFF
--- a/eventbus-jmh/build.gradle
+++ b/eventbus-jmh/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'eclipse'
     id 'java-library'
-    id 'net.minecraftforge.gradleutils' version '2.6.1'
+    id 'net.minecraftforge.gradleutils' version '3.2.5'
     id 'net.minecraftforge.licenser'
 }
 

--- a/eventbus-test-jar/build.gradle
+++ b/eventbus-test-jar/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'eclipse'
     id 'java-library'
-    id 'net.minecraftforge.gradleutils' version '2.6.1'
+    id 'net.minecraftforge.gradleutils' version '3.2.5'
     id 'net.minecraftforge.licenser'
 }
 

--- a/eventbus-test/build.gradle
+++ b/eventbus-test/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'eclipse'
     id 'java-library'
-    id 'net.minecraftforge.gradleutils' version '2.6.1'
+    id 'net.minecraftforge.gradleutils' version '3.2.5'
     id 'net.minecraftforge.licenser'
     id 'test-report-aggregation'
 }


### PR DESCRIPTION
Bumps net.minecraftforge.gradleutils from 2.6.1 to 3.2.5.

---
updated-dependencies:
- dependency-name: net.minecraftforge.gradleutils dependency-version: 3.2.5 dependency-type: direct:production update-type: version-update:semver-major ...